### PR TITLE
Change pebbli --test to pebbli --dev test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           name: pebbli-bin
           path: ${{ steps.findbin.outputs.bin }}
-
+          
   test:
     runs-on: ubuntu-latest
     needs: [build]
@@ -56,16 +56,28 @@ jobs:
           name: pebbli-bin
           path: ./bin
 
-      - name: Make binary executable
-        run: chmod +x ./bin/*
+      # Find the actual executable we just downloaded (could be nested)
+      - name: Locate downloaded binary
+        id: bin
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="$(find ./bin -maxdepth 5 -type f -executable | head -n1)"
+          if [ -z "${BIN:-}" ]; then
+            echo "No executable found under ./bin"; ls -R ./bin || true
+            exit 1
+          fi
+          echo "Found binary: $BIN"
+          echo "path=$BIN" >> "$GITHUB_OUTPUT"
 
-      # 1) If your interpreter supports an internal suite: run it
+      - name: Make binary executable
+        run: chmod +x "${{ steps.bin.outputs.path }}"
+
       - name: Run internal test mode (if supported)
         run: |
           set -e
-          ./bin/* --test || true   # don’t fail if --test isn’t supported; next step will validate
+          "${{ steps.bin.outputs.path }}" --dev test || true
 
-      # 2) Drive the REPL with your sample tests and assert outputs
       - name: Run REPL tests
         shell: bash
         run: |
@@ -85,10 +97,8 @@ jobs:
           let a = 5; let b = 10; a + b;
           EOF
 
-          # Run program; capture output
-          ./bin/* < input.pbl | tee actual.out
+          "${{ steps.bin.outputs.path }}" < input.pbl | tee actual.out
 
-          # Expected outputs (one per expression above).
           cat >expected.out <<'EOF'
           42
           3.140000
@@ -104,25 +114,14 @@ jobs:
           15
           EOF
 
-          # Normalize both (strip prompts like ">>> " and blank lines)
           sed -E 's/^>>> //; /^\s*$/d' actual.out > actual.norm
           sed -E 's/^\s+|\s+$//g' expected.out > expected.norm
 
-          # Check that expected lines appear in order in actual output
           awk 'NR==FNR{exp[NR]=$0; n=NR; next}
-               {
-                 gsub(/^\s+|\s+$/,"",$0);
-                 if ($0!="") actual[++m]=$0
-               }
-               END{
-                 i=j=1
-                 while (i<=n && j<=m){
-                   if (actual[j]==exp[i]) { i++; j++ } else { j++ }
-                 }
-                 if (i<=n){
-                   print "Missing expected line:", exp[i] > "/dev/stderr"
-                   exit 1
-                 }
-               }' expected.norm actual.norm
-
+              {gsub(/^\s+|\s+$/,"",$0); if($0!="") actual[++m]=$0}
+              END{
+                i=j=1
+                while(i<=n && j<=m){ if(actual[j]==exp[i]){i++; j++} else j++ }
+                if(i<=n){ print "Missing expected line:", exp[i] > "/dev/stderr"; exit 1 }
+              }' expected.norm actual.norm
           echo "All REPL checks passed."

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,20 +132,31 @@ int main(int argc, char* argv[]) {
     run_repl();
   } else if (argc == 2) {
     std::string arg = argv[1];
-    if (arg == "--test") {
-      test_interpreter();
-    } else if (arg == "--repl") {
+    if (arg == "--repl") {
       run_repl();
     } else {
       // Assume it's a filename
       run_file(arg);
     }
+  } else if (argc == 3) {
+    std::string arg1 = argv[1];
+    std::string arg2 = argv[2];
+    if (arg1 == "--dev" && arg2 == "test") {
+      test_interpreter();
+    } else {
+      std::cout << "Usage: " << argv[0] << " [--dev test|--repl|filename]" << std::endl;
+      std::cout << "  --dev test : Run interpreter tests" << std::endl;
+      std::cout << "  --repl     : Run interactive REPL" << std::endl;
+      std::cout << "  filename   : Execute a PEBBL source file" << std::endl;
+      std::cout << "  (no args)  : Start interactive REPL" << std::endl;
+      return 1;
+    }
   } else {
-    std::cout << "Usage: " << argv[0] << " [--test|--repl|filename]" << std::endl;
-    std::cout << "  --test    : Run interpreter tests" << std::endl;
-    std::cout << "  --repl    : Run interactive REPL" << std::endl;
-    std::cout << "  filename  : Execute a PEBBL source file" << std::endl;
-    std::cout << "  (no args) : Start interactive REPL" << std::endl;
+    std::cout << "Usage: " << argv[0] << " [--dev test|--repl|filename]" << std::endl;
+    std::cout << "  --dev test : Run interpreter tests" << std::endl;
+    std::cout << "  --repl     : Run interactive REPL" << std::endl;
+    std::cout << "  filename   : Execute a PEBBL source file" << std::endl;
+    std::cout << "  (no args)  : Start interactive REPL" << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
This is for users not accidently using a dev tool

## Summary
Changes --test to --dev test


## Checklist
- [x] Code builds and runs
- [x] Tests pass
- [x] Code is formatted (`clang-format`)
- [x] Modern C++ style is followed
- [x] Docs updated (if needed)